### PR TITLE
feat: merge upstream and increase rubocop support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,14 @@
-gem "rspec"
-gem "rspec-core"
-gem "rspec-rails"
-gem "rubocop", '~> 0.74.0'
-gem "rubocop-rspec"
+source 'https://rubygems.org'
+gem 'rspec'
+gem 'rspec-core'
+gem 'rspec-rails'
 
-#for test coverage
+# static code checking tools
+gem 'rubocop', '~> 0.79.0'
+gem 'rubocop-performance'
+gem 'rubocop-rails'
+gem 'rubocop-rake'
+gem 'rubocop-rspec'
+
+# for test coverage
 # gem 'simplecov', '~> 0.9.1', :require => false, :group => :test

--- a/lib/tasks/redmine.rake
+++ b/lib/tasks/redmine.rake
@@ -1,36 +1,36 @@
-require "rspec/core/rake_task"
+require 'rspec/core/rake_task'
 
 # Clear core's redmine:plugins:test task, else it's used
 # and our own version is never triggered
-Rake::Task["redmine:plugins:test"].clear
+Rake::Task['redmine:plugins:test'].clear
 
 namespace :redmine do
   namespace :plugins do
-    desc "Runs the plugins tests."
+    desc 'Runs the plugins tests.'
     task :test do
-      if !ENV["NAME"] || File.exists?(Rails.root.join("plugins/#{ENV["NAME"]}/spec"))
-        Rake::Task["redmine:plugins:spec"].invoke
+      if !ENV['NAME'] || File.exist?(Rails.root.join("plugins/#{ENV['NAME']}/spec"))
+        Rake::Task['redmine:plugins:spec'].invoke
       end
-      Rake::Task["redmine:plugins:test:units"].invoke
-      Rake::Task["redmine:plugins:test:functionals"].invoke
-      Rake::Task["redmine:plugins:test:integration"].invoke
+      Rake::Task['redmine:plugins:test:units'].invoke
+      Rake::Task['redmine:plugins:test:functionals'].invoke
+      Rake::Task['redmine:plugins:test:integration'].invoke
     end
 
-    desc "Runs the plugins spec."
-    RSpec::Core::RakeTask.new :spec => "db:test:prepare" do |t|
-      #current plugin (or all) spec/ directory
-      plugin_dir = "plugins/#{ENV["NAME"] || "*"}"
+    desc 'Runs the plugins spec.'
+    RSpec::Core::RakeTask.new spec: 'db:test:prepare' do |t|
+      # current plugin (or all) spec/ directory
+      plugin_dir = "plugins/#{ENV['NAME'] || '*'}"
       spec_dirs = Dir.glob("#{plugin_dir}/spec")
-      #add our spec/ directory to the path so other plugins can simply
-      #put this on top of their spec:
+      # add our spec/ directory to the path so other plugins can simply
+      # put this on top of their spec:
       #
       #   require "spec_helper"
       #
-      spec_dirs << File.expand_path("../../../spec", __FILE__)
-      #which spec to run
+      spec_dirs << File.expand_path('../../spec', __dir__)
+      # which spec to run
       t.pattern = "#{plugin_dir}/spec/**/*_spec.rb"
-      #which LOAD_PATH (for spec_helper especially)
-      t.ruby_opts = "-I#{spec_dirs.join(":")}"
+      # which LOAD_PATH (for spec_helper especially)
+      t.ruby_opts = "-I#{spec_dirs.join(':')}"
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,10 +1,12 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../../../../config/environment', __FILE__)
+require File.expand_path('../../../config/environment', __dir__)
+
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'spec_helper'
 require 'rspec/rails'
+
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,24 +1,24 @@
 ENV['RAILS_ENV'] ||= 'test'
 
-#load simplecov
+# load simplecov
 if ENV['COVERAGE']
   require 'simplecov'
   SimpleCov.start 'rails' do
     coverage_dir 'tmp/coverage'
 ###    require "pry"
 ###    binding.pry
-    #exclude core dirs coverage
+    # exclude core dirs coverage
     add_filter do |file|
-      file.filename.include?('/lib/plugins/') || 
+      file.filename.include?('/lib/plugins/') ||
         !file.filename.include?('/plugins/')
     end
   end
 end
 
-#load rails/redmine
-require File.expand_path('../../../../config/environment', __FILE__)
+# load rails/redmine
+require File.expand_path('../../../config/environment', __dir__)
 
-#test gems
+# test gems
 require 'rspec/rails'
 # require 'rspec/autorun'
 require 'rspec/mocks'
@@ -30,15 +30,15 @@ module AssertSelectRoot
   end
 end
 
-#rspec base config
+# rspec base config
 RSpec.configure do |config|
   config.mock_with :rspec
-  config.filter_run :focus => true
+  config.filter_run focus: true
   config.run_all_when_everything_filtered = true
   config.fixture_path = "#{::Rails.root}/test/fixtures"
   config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!
-  config.include AssertSelectRoot, :type => :request
+  config.include AssertSelectRoot, type: :request
 end
 
 def with_settings(options, &block)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,3 +40,19 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.include AssertSelectRoot, :type => :request
 end
+
+def with_settings(options, &block)
+  saved_settings = options.keys.inject({}) do |h, k|
+    h[k] = case Setting[k]
+           when Symbol, false, true, nil
+             Setting[k]
+           else
+             Setting[k].dup
+           end
+    h
+  end
+  options.each {|k, v| Setting[k] = v}
+  yield
+ensure
+  saved_settings.each {|k, v| Setting[k] = v} if saved_settings
+end


### PR DESCRIPTION
- merged changes from the original repos
- increased the rubocop version to 0.79 (still sticky to avoid unwanted effects of an uncontrolled update)
- added rails/rake/performance/rspec modules for rubocop
- code cleanup